### PR TITLE
Feature/rabbit client hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Unreleased
   - Add correct content type header to request
+  - Align async consumer with Pika docs
 
 ### 1.0.1 2017-02-17
   - Fix [#17 - RRM/CTP Typo](https://github.com/ONSdigital/sdx-receipt-ctp/issues/17)

--- a/app/async_consumer.py
+++ b/app/async_consumer.py
@@ -34,7 +34,6 @@ class AsyncConsumer(object):
         self._closing = False
         self._consumer_tag = None
         self._url = None
-        self._stopped = False
 
     def connect(self):
         """This method connects to RabbitMQ, returning the connection handle.
@@ -47,7 +46,7 @@ class AsyncConsumer(object):
         count = 1
         no_of_servers = len(settings.RABBIT_URLS)
 
-        while not self._stopped:
+        while True:
             server_choice = (count % no_of_servers) - 1
             self._url = settings.RABBIT_URLS[server_choice]
 
@@ -116,6 +115,9 @@ class AsyncConsumer(object):
 
             # Create a new connection
             self._connection = self.connect()
+
+            # There is now a new connection, needs a new ioloop to run
+            self._connection.ioloop.start()
 
     def add_on_channel_close_callback(self):
         """This method tells pika to call the on_channel_closed method if
@@ -357,5 +359,5 @@ class AsyncConsumer(object):
         logger.info('Stopping')
         self._closing = True
         self.stop_consuming()
-        self._stopped = True
+        self._connection.ioloop.start()
         logger.info('Stopped')

--- a/app/response_processor.py
+++ b/app/response_processor.py
@@ -72,7 +72,7 @@ class ResponseProcessor:
 
         try:
             res_logger.info("Calling service")
-            res = session.post(endpoint, data=data, headers=headers, verify=False, auth=auth)
+            res = session.post(endpoint, json=data, headers=headers, verify=False, auth=auth)
 
             res_logger = res_logger.bind(stats_code=res.status_code)
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 flake8==2.6.0
+mock==2.0.0
 six==1.10.0
 structlog==16.1.0


### PR DESCRIPTION
These changes align our code with the latest Pika docs async consumer example (0.10.0).
I've seen reports of bugs on restart in earlier versions. Maybe we had these issues in the past, and that's why we modified the code. But those reported issues are resolved in the current version of Pika.