### PR TITLE
Feature/log version number on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+  - Log version number on startup
   - Add correct content type header to request
   - Align async consumer with Pika docs
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,3 +2,5 @@ import logging
 from app import settings
 
 logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.LOGGING_FORMAT)
+
+__version__ = "1.0.1"

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -64,8 +64,7 @@ class Consumer(AsyncConsumer):
 
 
 def main():
-    logger.debug("Starting consumer")
-    logger.info("Current version: {}".format(__version__))
+    logger.debug("Starting consumer", version=__version__)
 
     if settings.SDX_RECEIPT_CTP_SECRET is None:
         logger.error("No SDX_RECEIPT_CTP_SECRET env var supplied")

--- a/app/consumer.py
+++ b/app/consumer.py
@@ -1,5 +1,6 @@
 import logging
 from structlog import wrap_logger
+from app import __version__
 from app.async_consumer import AsyncConsumer
 from app.response_processor import ResponseProcessor
 from app import settings
@@ -64,6 +65,7 @@ class Consumer(AsyncConsumer):
 
 def main():
     logger.debug("Starting consumer")
+    logger.info("Current version: {}".format(__version__))
 
     if settings.SDX_RECEIPT_CTP_SECRET is None:
         logger.error("No SDX_RECEIPT_CTP_SECRET env var supplied")


### PR DESCRIPTION
This is a pull request to add functionality that logs the current version number on service startup. The `__version__` variable in `console/init.py` contains the variable, which will need to be manually updated on a new release being cut. The version is logged at INFO level.